### PR TITLE
Added configurable proxy detection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A Puppet module for [apt-cacher-ng], with a `Vagrantfile` for quick
 deployment on [Vagrant].
 
+Requires puppetlabs 'stdlib' module
+
 Original author: [Alban Peignier]
 
 Maintainer of this fork: [Garth Kidd]
@@ -18,6 +20,11 @@ Other contributors:
 
         cd /etc/puppet/modules
         git clone git://github.com/garthk/puppet-apt-cacher-ng apt-cacher-ng
+
+* Install stdlib dependency (if not already present):
+        
+        cd /etc/puppet/modules
+        git clone git://github.com/puppetlabs/puppetlabs-stdlib.git stdlib
 
 * Edit the definition for your server to include `apt-cacher-ng`, perhaps
   specifying `version`:
@@ -40,6 +47,13 @@ Other contributors:
 
         class { 'apt-cacher-ng::client':
           servers => ["192.168.30.42:3142", "192.168.31.42:3142"],
+        }
+
+* To override proxy connection timeout:
+
+        class { 'apt-cacher-ng::client':
+          server  => "192.168.31.42:3142",
+          timeout => 15,
         }
 
 * To disable fallback to direct access if the proxy is not available:

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,4 +1,4 @@
-class apt-cacher-ng::client($server = "", $servers = "", $autodetect = true, $verbose = true, $timeout = undef) {
+class apt-cacher-ng::client($server = "", $servers = "", $autodetect = true, $verbose = true, $timeout = 30) {
   File {
     owner  => root,
     group  => root,
@@ -47,6 +47,9 @@ class apt-cacher-ng::client($server = "", $servers = "", $autodetect = true, $ve
             default: { fail("cannot specify both server and servers") }
           }
         }
+      }
+      if (!is_integer($timeout)) {
+        fail("timeout must be an integer")
       }
       file { "/etc/apt/detect-http-proxy": 
         content => template("apt-cacher-ng/detect-http-proxy.erb"),

--- a/templates/detect-http-proxy.erb
+++ b/templates/detect-http-proxy.erb
@@ -28,11 +28,7 @@ print_msg() {
 
 for proxy in "${try_proxies[@]}"; do
     # if the host machine / proxy is reachable...
-    <% if @timeout %>
     if nc -w <%= @timeout %> -z ${proxy/:/ }; then
-    <% else %>
-    if nc -z ${proxy/:/ }; then
-    <% end %>
         proxy=http://$proxy
         print_msg "Proxy that will be used: $proxy"
         echo "$proxy"


### PR DESCRIPTION
(Original Title: "Set proxy detection timeout to 2 seconds") The patch lowers the proxy detection timeout to 2 seconds down from the nc default of ~30 seconds. This prevents long waits if the primary proxy is not available. 
